### PR TITLE
off by one error in drawstring and drawstring_P

### DIFF
--- a/PCD8544.cpp
+++ b/PCD8544.cpp
@@ -130,7 +130,7 @@ void PCD8544::drawstring_P(uint8_t x, uint8_t line, const char *str) {
       return;
     drawchar(x, line, c);
     x += 6; // 6 pixels wide
-    if (x + 6 >= LCDWIDTH) {
+    if (x + 6 > LCDWIDTH) {
       x = 0;    // ran out of this line
       line++;
     }


### PR DESCRIPTION
Fixed in this commit. Would only display 13 characters even though there was room for 14.
