### PR TITLE
Update PCD8544.cpp

### DIFF
--- a/PCD8544.cpp
+++ b/PCD8544.cpp
@@ -21,6 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 
+// Albert uint8_t = byte
+
 //#include <Wire.h>
 #include <avr/pgmspace.h>
 #if defined(ARDUINO) && ARDUINO >= 100
@@ -34,14 +36,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "PCD8544.h"
 #include "glcdfont.c"
 
-uint8_t is_reversed = 0;
+byte is_reversed = 0;
 
 
 // a 5x7 font table
-extern uint8_t PROGMEM font[];
+extern byte PROGMEM font[];
 
 // the memory buffer for the LCD
-uint8_t pcd8544_buffer[LCDWIDTH * LCDHEIGHT / 8] = {
+byte pcd8544_buffer[LCDWIDTH * LCDHEIGHT / 8] = {
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFC, 0xFE, 0xFF, 0xFC, 0xE0,
@@ -83,12 +85,91 @@ uint8_t pcd8544_buffer[LCDWIDTH * LCDHEIGHT / 8] = {
 //#define enablePartialUpdate
 
 #ifdef enablePartialUpdate
-static uint8_t xUpdateMin, xUpdateMax, yUpdateMin, yUpdateMax;
+static byte xUpdateMin, xUpdateMax, yUpdateMin, yUpdateMax;
 #endif
 
+PCD8544::PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t CS, int8_t RST) // If CS and RST are not used make them 0  Albert 
+{ _din = DIN;
+  _sclk = SCLK;
+  _dc = DC;
+  _rst = RST;
+  _cs = CS;
+
+  cursor_x = cursor_y = 0;
+  textsize = 1;
+  textcolor = BLACK;  
+}
+
+/* // Albert do not use duplical code, use default parameters
+PCD8544::PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t RST) { 
+  _din = DIN;
+  _sclk = SCLK;
+  _dc = DC;
+  _rst = RST;
+  _cs = -1;
+  
+  cursor_x = cursor_y = 0;
+  textsize = 1;
+  textcolor = BLACK;
+}
+*/
+
+void PCD8544::init(byte contrast) { // Albert use default parameters
+  // set pin directions
+  pinMode(_din, OUTPUT); // Albert 
+  pinMode(_sclk, OUTPUT);
+  pinMode(_dc, OUTPUT);
+  
+  if(_rst > 0) // Albert
+  { pinMode(_rst, OUTPUT);     
+    digitalWrite(_rst, LOW); // toggle RST low to reset
+    // _delay_ms(500); // Albert
+    _delay_ms(1); // Albert just 100ns is fine
+    digitalWrite(_rst, HIGH); 
+  }  
+  
+  if(_cs > 0) // Albert
+  { pinMode(_cs, OUTPUT); 
+    // CS low so it'll listen to us
+    digitalWrite(_cs, LOW); // Albert attention: _cs is never put high anymore, this has to be changed
+  }
+  
+  // get into the EXTENDED mode!
+  command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
+
+  // LCD bias select (4 is optimal?)
+  command(PCD8544_SETBIAS | 0x4); 
+
+  // set VOP
+  if (contrast > 0x7f)
+    contrast = 0x7f;
+
+  command( PCD8544_SETVOP | contrast); // Experimentally determined
 
 
-static void updateBoundingBox(uint8_t xmin, uint8_t ymin, uint8_t xmax, uint8_t ymax) {
+  // normal mode
+  command(PCD8544_FUNCTIONSET);
+
+  // Set display to Normal
+  command(PCD8544_DISPLAYCONTROL | PCD8544_DISPLAYNORMAL);
+
+  // initial display line
+  // set page address
+  // set column address
+  // write display data
+
+  // set up a bounding box for screen updates
+
+  //updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1); // Albert use displayBuffer()
+  // Push out pcd8544_buffer to the Display (will show the AFI logo) // Albert use displayBuffer()
+  //display(); // Albert use displayBuffer()
+  //_delay_ms(1000); // Albert use displayBuffer()
+  // Clear the display
+  clear(); 
+  display();
+}
+
+static void updateBoundingBox(byte xmin, byte ymin, byte xmax, byte ymax) {
 #ifdef enablePartialUpdate
   if (xmin < xUpdateMin) xUpdateMin = xmin;
   if (xmax > xUpdateMax) xUpdateMax = xmax;
@@ -97,36 +178,11 @@ static void updateBoundingBox(uint8_t xmin, uint8_t ymin, uint8_t xmax, uint8_t 
 #endif
 }
 
-PCD8544::PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t CS, int8_t RST) {
-  _din = DIN;
-  _sclk = SCLK;
-  _dc = DC;
-  _rst = RST;
-  _cs = CS;
-  cursor_x = cursor_y = 0;
-  textsize = 1;
-  textcolor = BLACK;
-}
-
-
-
-PCD8544::PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t RST) {
-  _din = DIN;
-  _sclk = SCLK;
-  _dc = DC;
-  _rst = RST;
-  _cs = -1;
-  cursor_x = cursor_y = 0;
-  textsize = 1;
-  textcolor = BLACK;
-
-}
-
-void PCD8544::drawbitmap(uint8_t x, uint8_t y, 
-			const uint8_t *bitmap, uint8_t w, uint8_t h,
-			uint8_t color) {
-  for (uint8_t j=0; j<h; j++) {
-    for (uint8_t i=0; i<w; i++ ) {
+void PCD8544::drawbitmap(byte x, byte y, 
+			const byte *bitmap, byte w, byte h,
+			byte color) {
+  for (byte j=0; j<h; j++) {
+    for (byte i=0; i<w; i++ ) {
       if (pgm_read_byte(bitmap + i + (j/8)*w) & _BV(j%8)) {
 	my_setpixel(x+i, y+j, color);
       }
@@ -137,14 +193,14 @@ void PCD8544::drawbitmap(uint8_t x, uint8_t y,
 }
 
 
-void PCD8544::drawstring(uint8_t x, uint8_t y, char *c) {
+void PCD8544::drawstring(byte x, byte y, char *c) {
   cursor_x = x;
   cursor_y = y;
   print(c);
 }
 
 
-void PCD8544::drawstring_P(uint8_t x, uint8_t y, const char *str) {
+void PCD8544::drawstring_P(byte x, byte y, const char *str) {
   cursor_x = x;
   cursor_y = y;
   while (1) {
@@ -155,13 +211,13 @@ void PCD8544::drawstring_P(uint8_t x, uint8_t y, const char *str) {
   }
 }
 
-void  PCD8544::drawchar(uint8_t x, uint8_t y, char c) {
+void  PCD8544::drawchar(byte x, byte y, char c) {
   if (y >= LCDHEIGHT) return;
   if ((x+5) >= LCDWIDTH) return;
 
-  for (uint8_t i =0; i<5; i++ ) {
-    uint8_t d = pgm_read_byte(font+(c*5)+i);
-    for (uint8_t j = 0; j<8; j++) {
+  for (byte i =0; i<5; i++ ) {
+    byte d = pgm_read_byte(font+(c*5)+i);
+    for (byte j = 0; j<8; j++) {
       if (d & _BV(j)) {
 	my_setpixel(x+i, y+j, textcolor);
       }
@@ -170,16 +226,16 @@ void  PCD8544::drawchar(uint8_t x, uint8_t y, char c) {
       }
     }
   }
-  for (uint8_t j = 0; j<8; j++) {
+  for (byte j = 0; j<8; j++) {
     my_setpixel(x+5, y+j, !textcolor);
   }
   updateBoundingBox(x, y, x+5, y + 8);
 }
 
 #if defined(ARDUINO) && ARDUINO >= 100
-  size_t PCD8544::write(uint8_t c) {
+  size_t PCD8544::write(byte c) {
 #else
-  void PCD8544::write(uint8_t c) {
+  void PCD8544::write(byte c) {
 #endif
   if (c == '\n') {
     cursor_y += textsize*8;
@@ -198,16 +254,16 @@ void  PCD8544::drawchar(uint8_t x, uint8_t y, char c) {
   }
 }
 
-void PCD8544::setCursor(uint8_t x, uint8_t y){
+void PCD8544::setCursor(byte x, byte y){
   cursor_x = x; 
   cursor_y = y;
 }
 
 
 // bresenham's algorithm - thx wikpedia
-void PCD8544::drawline(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, 
-		      uint8_t color) {
-  uint8_t steep = abs(y1 - y0) > abs(x1 - x0);
+void PCD8544::drawline(byte x0, byte y0, byte x1, byte y1, 
+		      byte color) {
+  byte steep = abs(y1 - y0) > abs(x1 - x0);
   if (steep) {
     swap(x0, y0);
     swap(x1, y1);
@@ -221,7 +277,7 @@ void PCD8544::drawline(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
   // much faster to put the test here, since we've already sorted the points
   updateBoundingBox(x0, y0, x1, y1);
 
-  uint8_t dx, dy;
+  byte dx, dy;
   dx = x1 - x0;
   dy = abs(y1 - y0);
 
@@ -249,12 +305,12 @@ void PCD8544::drawline(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
 
 
 // filled rectangle
-void PCD8544::fillrect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, 
-		      uint8_t color) {
+void PCD8544::fillrect(byte x, byte y, byte w, byte h, 
+		      byte color) {
 
   // stupidest version - just pixels - but fast with internal buffer!
-  for (uint8_t i=x; i<x+w; i++) {
-    for (uint8_t j=y; j<y+h; j++) {
+  for (byte i=x; i<x+w; i++) {
+    for (byte j=y; j<y+h; j++) {
       my_setpixel(i, j, color);
     }
   }
@@ -263,14 +319,14 @@ void PCD8544::fillrect(uint8_t x, uint8_t y, uint8_t w, uint8_t h,
 }
 
 // draw a rectangle
-void PCD8544::drawrect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, 
-		      uint8_t color) {
+void PCD8544::drawrect(byte x, byte y, byte w, byte h, 
+		      byte color) {
   // stupidest version - just pixels - but fast with internal buffer!
-  for (uint8_t i=x; i<x+w; i++) {
+  for (byte i=x; i<x+w; i++) {
     my_setpixel(i, y, color);
     my_setpixel(i, y+h-1, color);
   }
-  for (uint8_t i=y; i<y+h; i++) {
+  for (byte i=y; i<y+h; i++) {
     my_setpixel(x, i, color);
     my_setpixel(x+w-1, i, color);
   } 
@@ -279,8 +335,8 @@ void PCD8544::drawrect(uint8_t x, uint8_t y, uint8_t w, uint8_t h,
 }
 
 // draw a circle outline
-void PCD8544::drawcircle(uint8_t x0, uint8_t y0, uint8_t r, 
-			uint8_t color) {
+void PCD8544::drawcircle(byte x0, byte y0, byte r, 
+			byte color) {
   updateBoundingBox(x0-r, y0-r, x0+r, y0+r);
 
   int8_t f = 1 - r;
@@ -317,8 +373,8 @@ void PCD8544::drawcircle(uint8_t x0, uint8_t y0, uint8_t r,
   }
 }
 
-void PCD8544::fillcircle(uint8_t x0, uint8_t y0, uint8_t r, 
-			uint8_t color) {
+void PCD8544::fillcircle(byte x0, byte y0, byte r, 
+			byte color) {
   updateBoundingBox(x0-r, y0-r, x0+r, y0+r);
 
   int8_t f = 1 - r;
@@ -327,7 +383,7 @@ void PCD8544::fillcircle(uint8_t x0, uint8_t y0, uint8_t r,
   int8_t x = 0;
   int8_t y = r;
 
-  for (uint8_t i=y0-r; i<=y0+r; i++) {
+  for (byte i=y0-r; i<=y0+r; i++) {
     my_setpixel(x0, i, color);
   }
 
@@ -341,11 +397,11 @@ void PCD8544::fillcircle(uint8_t x0, uint8_t y0, uint8_t r,
     ddF_x += 2;
     f += ddF_x;
   
-    for (uint8_t i=y0-y; i<=y0+y; i++) {
+    for (byte i=y0-y; i<=y0+y; i++) {
       my_setpixel(x0+x, i, color);
       my_setpixel(x0-x, i, color);
     } 
-    for (uint8_t i=y0-x; i<=y0+x; i++) {
+    for (byte i=y0-x; i<=y0+x; i++) {
       my_setpixel(x0+y, i, color);
       my_setpixel(x0-y, i, color);
     }    
@@ -353,7 +409,7 @@ void PCD8544::fillcircle(uint8_t x0, uint8_t y0, uint8_t r,
 }
 
 
-void PCD8544::my_setpixel(uint8_t x, uint8_t y, uint8_t color) {
+void PCD8544::my_setpixel(byte x, byte y, byte color) {
   if ((x >= LCDWIDTH) || (y >= LCDHEIGHT))
     return;
 
@@ -367,7 +423,7 @@ void PCD8544::my_setpixel(uint8_t x, uint8_t y, uint8_t color) {
 
 
 // the most basic function, set a single pixel
-void PCD8544::setPixel(uint8_t x, uint8_t y, uint8_t color) {
+void PCD8544::setPixel(byte x, byte y, byte color) {
   if ((x >= LCDWIDTH) || (y >= LCDHEIGHT))
     return;
 
@@ -382,84 +438,43 @@ void PCD8544::setPixel(uint8_t x, uint8_t y, uint8_t color) {
 
 
 // the most basic function, get a single pixel
-uint8_t PCD8544::getPixel(uint8_t x, uint8_t y) {
+byte PCD8544::getPixel(byte x, byte y) {
   if ((x >= LCDWIDTH) || (y >= LCDHEIGHT))
     return 0;
 
   return (pcd8544_buffer[x+ (y/8)*LCDWIDTH] >> (7-(y%8))) & 0x1;  
 }
 
+
+/* Albert use default parameters
 void PCD8544::init(void) {
   init(50);
 }
-
-void PCD8544::init(uint8_t contrast) {
-  // set pin directions
-  pinMode(_din, OUTPUT);
-  pinMode(_sclk, OUTPUT);
-  pinMode(_dc, OUTPUT);
-  pinMode(_rst, OUTPUT);
-  pinMode(_cs, OUTPUT);
-
-  // toggle RST low to reset; CS low so it'll listen to us
-  if (_cs > 0)
-    digitalWrite(_cs, LOW);
-
-  digitalWrite(_rst, LOW);
-  _delay_ms(500);
-  digitalWrite(_rst, HIGH);
+*/
 
 
-  // get into the EXTENDED mode!
-  command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
-
-  // LCD bias select (4 is optimal?)
-  command(PCD8544_SETBIAS | 0x4);
-
-  // set VOP
-  if (contrast > 0x7f)
-    contrast = 0x7f;
-
-  command( PCD8544_SETVOP | contrast); // Experimentally determined
-
-
-  // normal mode
-  command(PCD8544_FUNCTIONSET);
-
-  // Set display to Normal
-  command(PCD8544_DISPLAYCONTROL | PCD8544_DISPLAYNORMAL);
-
-  // initial display line
-  // set page address
-  // set column address
-  // write display data
-
-  // set up a bounding box for screen updates
-
-  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+void PCD8544::displayBuffer() // Albert
+{ updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
   // Push out pcd8544_buffer to the Display (will show the AFI logo)
   display();
   _delay_ms(1000);
-  // Clear the display
-  clear(); 
-  display();
 }
 
-inline void PCD8544::spiwrite(uint8_t c) {
+inline void PCD8544::spiwrite(byte c) {
   shiftOut(_din, _sclk, MSBFIRST, c);
 }
 
-void PCD8544::command(uint8_t c) {
+void PCD8544::command(byte c) {
   digitalWrite(_dc, LOW);
   spiwrite(c);
 }
 
-void PCD8544::data(uint8_t c) {
+void PCD8544::data(byte c) {
   digitalWrite(_dc, HIGH);
   spiwrite(c);
 }
 
-void PCD8544::setContrast(uint8_t val) {
+void PCD8544::setContrast(byte val) {
   if (val > 0x7f) {
     val = 0x7f;
   }
@@ -472,7 +487,7 @@ void PCD8544::setContrast(uint8_t val) {
 
 
 void PCD8544::display(void) {
-  uint8_t col, maxcol, p;
+  byte col, maxcol, p;
   
   for(p = 0; p < 6; p++) {
 #ifdef enablePartialUpdate
@@ -527,7 +542,7 @@ void PCD8544::clear(void) {
 // this doesnt touch the buffer, just clears the display RAM - might be handy
 void PCD8544::clearDisplay(void) {
   
-  uint8_t p, c;
+  byte p, c;
   
   for(p = 0; p < 8; p++) {
 


### PR DESCRIPTION
Dear Limor,

Thank you for your work on the Nokia LCD library. I will use it on my solar bike
http://www.avdweb.nl/index.php

Here is my page about the Nokia 5110 LCD
http://www.avdweb.nl/arduino/nokia-5110-lcd.html

I have done little improvements to the library, search on “Albert” and you see all changes to the code.

Allow 3 pin, 4 pin or 5 pin LCD control.
CS and RST will not set to pinmode output when not used and we can use the pins for other purposes.
Some allowed class initialisations:
PCD8544 nokia = PCD8544(9, 10, 11);  or
PCD8544 nokia = PCD8544(9, 10, 11, 0, 0); 
PCD8544 nokia = PCD8544(9, 10, 11, 0, 12); 
PCD8544 nokia = PCD8544(9, 10, 11, 12, 0); 
PCD8544 nokia = PCD8544(9, 10, 11, 12, 13); 

This is improved too:
Add the #ifndef PCD8544_H at the top oh the header
Using default parameters to simplify the code and avoid duplical code
Changes uint8_t to byte for better readability

Changes to init():
Simplified the code
Refactoring by using a function displayBuffer() for show the AFI logo
