### PR TITLE
Update Adafruit_PCD8544.cpp

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -131,7 +131,7 @@ uint8_t Adafruit_PCD8544::getPixel(int8_t x, int8_t y) {
   if ((x < 0) || (x >= LCDWIDTH) || (y < 0) || (y >= LCDHEIGHT))
     return 0;
 
-  return (pcd8544_buffer[x+ (y/8)*LCDWIDTH] >> (7-(y%8))) & 0x1;  
+  return (pcd8544_buffer[x+ (y/8)*LCDWIDTH] >> (y%8)) & 0x1;  
 }
 
 


### PR DESCRIPTION
Formula was simply wrong (IMHO), I was wrote the following function in Adafruit_GFX.cpp (had to add the `virtual uint8_t getPixel(int8_t x, int8_t y);` in Adafruit_GFX.h):

``` c
void Adafruit_GFX::shiftScreen() {
   /* Shift screen 6 lines up */
    cursor_y -= 6;
    for (int8_t ally = 0; ally<_height-6; ally++)
    {
        for (int8_t allx = 0; allx<_width; allx++)
        {
            drawPixel(allx, ally, getPixel(allx, ally+6));
        }
    }
    fillRect(0, _height-6, _width, 6, 0);
}
```

The result was garbage. After my patch, everything works as expected.
