### PR TITLE
write an xbm file to the buffer

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -121,6 +121,25 @@ void Adafruit_PCD8544::drawPixel(int16_t x, int16_t y, uint16_t color) {
   updateBoundingBox(x,y,x,y);
 }
 
+// draws an 1 bit xbm to the buffer
+void Adafruit_PCD8544::drawXbm(int16_t x_off, int16_t y_off, unsigned char *xbm, int16_t w, int16_t h, bool inverted) {
+    int16_t row, col, byo, bmo;
+
+    int8_t yes = inverted ? 0 : 1;
+    int8_t no  = inverted ? 1 : 0;
+
+    for (row = 0; row < h; row += 7) {
+        for (col = 0; col < w; col++) {
+            int y = 7;
+            while (y > 0) {
+                byo = ((row + y) * ((w + 7) / 8)) + (col / 8);
+                bmo = 1 << (col % 8);
+                drawPixel(col + x_off, (row + y + y_off) - 1, ((xbm[byo] & bmo) ? yes : no));
+                y--;
+            }
+        }
+    }
+}
 
 // the most basic function, get a single pixel
 uint8_t Adafruit_PCD8544::getPixel(int8_t x, int8_t y) {

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -64,6 +64,8 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   void display();
   
   void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void drawXbm(int16_t x_off, int16_t y_off, unsigned char *xbm, int16_t w, int16_t h, bool inverted = false);
+
   uint8_t getPixel(int8_t x, int8_t y);
 
  private:


### PR DESCRIPTION
Hi,

I wrote a simple method to write an xbm file to the buffer. Use it to display an image, or use it to display menu items. The "inverted" parameter could used to mark an item active. 

Creating a XBM file is very easy using Gimp. Create an Image with the size of 84x48, monochrome and save or export it as a xbm file. Import the created file in your main.c/cpp with the include directive:
    "#include <filename.xbm>". 
Draw the image using:
    drawXbm(0, 0, filename_bits, filename_width, filename_height);

Hope you find it useful!
