### PR TITLE
Add hardware SPI

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -4,30 +4,25 @@ This is a library for our Monochrome Nokia 5110 LCD Displays
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/338
 
-These displays use SPI to communicate, 4 or 5 pins are required to  
+These displays use SPI to communicate, 4 or 5 pins are required to
 interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada  for Adafruit Industries.  
+Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen below must be included in any redistribution
 *********************************************************************/
 
-//#include <Wire.h>
-#include <avr/pgmspace.h>
-#if defined(ARDUINO) && ARDUINO >= 100
-  #include "Arduino.h"
-#else
-  #include "WProgram.h"
-#endif
-#include <util/delay.h>
-#include <stdlib.h>
-
-#include <Adafruit_GFX.h>
 #include "Adafruit_PCD8544.h"
+#include <limits.h>
+#include "pins_arduino.h"
+#include "wiring_private.h"
+#include <SPI.h>
+// #include <util/delay.h>
+// #include <stdlib.h>
 
 // the memory buffer for the LCD
 uint8_t pcd8544_buffer[LCDWIDTH * LCDHEIGHT / 8] = {
@@ -62,20 +57,17 @@ uint8_t pcd8544_buffer[LCDWIDTH * LCDHEIGHT / 8] = {
 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x0F, 0x1F, 0x3F, 0x7F, 0x7F,
 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x7F, 0x1F, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
 
 // reduces how much is refreshed, which speeds it up!
-// originally derived from Steve Evans/JCW's mod but cleaned up and
-// optimized
-//#define enablePartialUpdate
+// originally derived from Steve Evans/JCW's mod but cleaned up and optimized
+#define enablePartialUpdate
 
 #ifdef enablePartialUpdate
 static uint8_t xUpdateMin, xUpdateMax, yUpdateMin, yUpdateMax;
 #endif
-
-
 
 static void updateBoundingBox(uint8_t xmin, uint8_t ymin, uint8_t xmax, uint8_t ymax) {
 #ifdef enablePartialUpdate
@@ -86,22 +78,207 @@ static void updateBoundingBox(uint8_t xmin, uint8_t ymin, uint8_t xmax, uint8_t 
 #endif
 }
 
-Adafruit_PCD8544::Adafruit_PCD8544(int8_t SCLK, int8_t DIN, int8_t DC,
-    int8_t CS, int8_t RST) : Adafruit_GFX(LCDWIDTH, LCDHEIGHT) {
-  _din = DIN;
-  _sclk = SCLK;
-  _dc = DC;
-  _rst = RST;
-  _cs = CS;
+
+// Constructor when using software SPI.  All output pins are configurable.
+Adafruit_PCD8544::Adafruit_PCD8544(uint8_t cs, uint8_t rs, uint8_t sid,
+ uint8_t sclk, uint8_t rst) : Adafruit_GFX(LCDWIDTH, LCDHEIGHT) {
+  _cs   = cs;
+  _rs   = rs;
+  _sid  = sid;
+  _sclk = sclk;
+  _rst  = rst;
+  hwSPI = false;
 }
 
-Adafruit_PCD8544::Adafruit_PCD8544(int8_t SCLK, int8_t DIN, int8_t DC,
-    int8_t RST) : Adafruit_GFX(LCDWIDTH, LCDHEIGHT) {
-  _din = DIN;
-  _sclk = SCLK;
-  _dc = DC;
-  _rst = RST;
-  _cs = -1;
+
+// Constructor when using hardware SPI.  Faster, but must use SPI pins
+// specific to each board type (e.g. 11,13 for Uno, 51,52 for Mega, etc.)
+Adafruit_PCD8544::Adafruit_PCD8544(uint8_t cs, uint8_t rs, uint8_t rst) :
+    Adafruit_GFX(LCDWIDTH, LCDHEIGHT) {
+  _cs   = cs;
+  _rs   = rs;
+  _rst  = rst;
+  hwSPI = true;
+  _sid  = _sclk = 0;
+}
+
+
+#ifdef __AVR__
+inline void Adafruit_PCD8544::spiwrite(uint8_t c) {
+  //Serial.println(c, HEX);
+  if (hwSPI) {
+    SPDR = c;
+    while(!(SPSR & _BV(SPIF)));
+  } else {
+    // Fast SPI bitbang swiped from LPD8806 library
+    for(uint8_t bit = 0x80; bit; bit >>= 1) {
+      if(c & bit) *dataport |=  datapinmask;
+      else        *dataport &= ~datapinmask;
+      *clkport |=  clkpinmask;
+      *clkport &= ~clkpinmask;
+    }
+    // Slow SPI bitbang shiftOut(_din, _sclk, MSBFIRST, c);
+  }
+}
+
+
+void Adafruit_PCD8544::writecommand(uint8_t c) {
+  *rsport &= ~rspinmask;
+  *csport &= ~cspinmask;
+
+  //Serial.print("C ");
+  spiwrite(c);
+
+  *csport |= cspinmask;
+}
+
+
+void Adafruit_PCD8544::writedata(uint8_t c) {
+  *rsport |=  rspinmask;
+  *csport &= ~cspinmask;
+
+  //Serial.print("D ");
+  spiwrite(c);
+
+  *csport |= cspinmask;
+}
+#endif //#ifdef __AVR__
+
+
+#if defined(__SAM3X8E__)
+inline void Adafruit_PCD8544::spiwrite(uint8_t c) {
+  //Serial.println(c, HEX);
+  if (hwSPI) {
+    SPI.transfer(c);
+  } else {
+    // Fast SPI bitbang swiped from LPD8806 library
+    for(uint8_t bit = 0x80; bit; bit >>= 1) {
+      if(c & bit) dataport->PIO_SODR |= datapinmask;
+      else        dataport->PIO_CODR |= datapinmask;
+      clkport->PIO_SODR |= clkpinmask;
+      clkport->PIO_CODR |= clkpinmask;
+    }
+  }
+}
+
+
+void Adafruit_PCD8544::writecommand(uint8_t c) {
+  rsport->PIO_CODR |= rspinmask;
+  csport->PIO_CODR |= cspinmask;
+
+  //Serial.print("C ");
+  spiwrite(c);
+
+  csport->PIO_SODR |= cspinmask;
+}
+
+
+void Adafruit_PCD8544::writedata(uint8_t c) {
+  rsport->PIO_SODR |= rspinmask;
+  csport->PIO_CODR |= cspinmask;
+
+  //Serial.print("D ");
+  spiwrite(c);
+
+  csport->PIO_SODR |= cspinmask;
+}
+#endif //#if defined(__SAM3X8E__)
+
+
+void Adafruit_PCD8544::begin(uint8_t contrast) {
+  pinMode(_rs, OUTPUT);
+  pinMode(_cs, OUTPUT);
+#ifdef __AVR__
+  csport    = portOutputRegister(digitalPinToPort(_cs));
+  rsport    = portOutputRegister(digitalPinToPort(_rs));
+#endif
+#if defined(__SAM3X8E__)
+  csport    = digitalPinToPort(_cs);
+  rsport    = digitalPinToPort(_rs);
+#endif
+  cspinmask = digitalPinToBitMask(_cs);
+  rspinmask = digitalPinToBitMask(_rs);
+
+  if(hwSPI) { // Using hardware SPI
+    SPI.begin();
+#ifdef __AVR__
+    SPI.setClockDivider(SPI_CLOCK_DIV4); // 4 MHz (half speed)
+    //Due defaults to 4mHz (clock divider setting of 21)
+#endif
+#if defined(__SAM3X8E__)
+    SPI.setClockDivider(21); // 4 MHz
+    //Due defaults to 4mHz (clock divider setting of 21), but we'll set it anyway
+#endif
+    SPI.setBitOrder(MSBFIRST);
+    SPI.setDataMode(SPI_MODE0);
+  } else {
+    pinMode(_sclk, OUTPUT);
+    pinMode(_sid , OUTPUT);
+#ifdef __AVR__
+    clkport     = portOutputRegister(digitalPinToPort(_sclk));
+    dataport    = portOutputRegister(digitalPinToPort(_sid));
+#endif
+#if defined(__SAM3X8E__)
+    clkport     = digitalPinToPort(_sclk);
+    dataport    = digitalPinToPort(_sid);
+#endif
+    clkpinmask  = digitalPinToBitMask(_sclk);
+    datapinmask = digitalPinToBitMask(_sid);
+#ifdef __AVR__
+    *clkport   &= ~clkpinmask;
+    *dataport  &= ~datapinmask;
+#endif
+#if defined(__SAM3X8E__)
+    clkport ->PIO_CODR |= clkpinmask; // Set control bits to LOW (idle)
+    dataport->PIO_CODR |= datapinmask; // Signals are ACTIVE HIGH
+#endif
+  }
+
+  // toggle RST low to reset; CS low so it'll listen to us
+#ifdef __AVR__
+  *csport &= ~cspinmask;
+#endif
+#if defined(__SAM3X8E__)
+  csport ->PIO_CODR |= cspinmask; // Set control bits to LOW (idle)
+#endif
+  if (_rst) {
+    pinMode(_rst, OUTPUT);
+    digitalWrite(_rst, HIGH);
+    delay(500);
+    digitalWrite(_rst, LOW);
+    delay(500);
+    digitalWrite(_rst, HIGH);
+    delay(500);
+  }
+  // END common SPI code
+
+  // get into the EXTENDED mode!
+  writecommand(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
+
+  // LCD bias select (4 is optimal?)
+  writecommand(PCD8544_SETBIAS | 0x4);
+
+  // set VOP
+  if (contrast > 0x7f)
+    contrast = 0x7f;
+  writecommand(PCD8544_SETVOP | contrast); // Experimentally determined
+
+  // normal mode
+  writecommand(PCD8544_FUNCTIONSET);
+
+  // Set display to Normal
+  writecommand(PCD8544_DISPLAYCONTROL | PCD8544_DISPLAYNORMAL);
+
+  // initial display line
+  // set page address
+  // set column address
+  // write display data
+
+  // set up a bounding box for screen updates
+  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+  
+  // Push out pcd8544_buffer to the Display (will show the AFI logo)
+  display();
 }
 
 
@@ -111,10 +288,10 @@ void Adafruit_PCD8544::drawPixel(int16_t x, int16_t y, uint16_t color) {
     return;
 
   // x is which column
-  if (color) 
-    pcd8544_buffer[x+ (y/8)*LCDWIDTH] |= _BV(y%8);  
+  if (color)
+    pcd8544_buffer[x+ (y/8)*LCDWIDTH] |= _BV(y%8);
   else
-    pcd8544_buffer[x+ (y/8)*LCDWIDTH] &= ~_BV(y%8); 
+    pcd8544_buffer[x+ (y/8)*LCDWIDTH] &= ~_BV(y%8);
 
   updateBoundingBox(x,y,x,y);
 }
@@ -125,115 +302,23 @@ uint8_t Adafruit_PCD8544::getPixel(int8_t x, int8_t y) {
   if ((x < 0) || (x >= LCDWIDTH) || (y < 0) || (y >= LCDHEIGHT))
     return 0;
 
-  return (pcd8544_buffer[x+ (y/8)*LCDWIDTH] >> (y%8)) & 0x1;  
+  return (pcd8544_buffer[x+ (y/8)*LCDWIDTH] >> (y%8)) & 0x1;
 }
 
-
-void Adafruit_PCD8544::begin(uint8_t contrast) {
-  // set pin directions
-  pinMode(_din, OUTPUT);
-  pinMode(_sclk, OUTPUT);
-  pinMode(_dc, OUTPUT);
-  if (_rst > 0)
-    pinMode(_rst, OUTPUT);
-  if (_cs > 0)
-    pinMode(_cs, OUTPUT);
-
-  // toggle RST low to reset
-  if (_rst > 0) {
-    digitalWrite(_rst, LOW);
-    _delay_ms(500);
-    digitalWrite(_rst, HIGH);
-  }
-
-  clkport     = portOutputRegister(digitalPinToPort(_sclk));
-  clkpinmask  = digitalPinToBitMask(_sclk);
-  mosiport    = portOutputRegister(digitalPinToPort(_din));
-  mosipinmask = digitalPinToBitMask(_din);
-  csport    = portOutputRegister(digitalPinToPort(_cs));
-  cspinmask = digitalPinToBitMask(_cs);
-  dcport    = portOutputRegister(digitalPinToPort(_dc));
-  dcpinmask = digitalPinToBitMask(_dc);
-
-  // get into the EXTENDED mode!
-  command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
-
-  // LCD bias select (4 is optimal?)
-  command(PCD8544_SETBIAS | 0x4);
-
-  // set VOP
-  if (contrast > 0x7f)
-    contrast = 0x7f;
-
-  command( PCD8544_SETVOP | contrast); // Experimentally determined
-
-
-  // normal mode
-  command(PCD8544_FUNCTIONSET);
-
-  // Set display to Normal
-  command(PCD8544_DISPLAYCONTROL | PCD8544_DISPLAYNORMAL);
-
-  // initial display line
-  // set page address
-  // set column address
-  // write display data
-
-  // set up a bounding box for screen updates
-
-  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
-  // Push out pcd8544_buffer to the Display (will show the AFI logo)
-  display();
-}
-
-
-inline void Adafruit_PCD8544::fastSPIwrite(uint8_t d) {
-  
-  for(uint8_t bit = 0x80; bit; bit >>= 1) {
-    *clkport &= ~clkpinmask;
-    if(d & bit) *mosiport |=  mosipinmask;
-    else        *mosiport &= ~mosipinmask;
-    *clkport |=  clkpinmask;
-  }
-}
-
-inline void Adafruit_PCD8544::slowSPIwrite(uint8_t c) {
-  shiftOut(_din, _sclk, MSBFIRST, c);
-}
-
-void Adafruit_PCD8544::command(uint8_t c) {
-  digitalWrite(_dc, LOW);
-  if (_cs > 0)
-    digitalWrite(_cs, LOW);
-  fastSPIwrite(c);
-  if (_cs > 0)
-    digitalWrite(_cs, HIGH);
-}
-
-void Adafruit_PCD8544::data(uint8_t c) {
-  digitalWrite(_dc, HIGH);
-  if (_cs > 0)
-    digitalWrite(_cs, LOW);
-  fastSPIwrite(c);
-  if (_cs > 0)
-    digitalWrite(_cs, HIGH);
-}
 
 void Adafruit_PCD8544::setContrast(uint8_t val) {
   if (val > 0x7f) {
     val = 0x7f;
   }
-  command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
-  command( PCD8544_SETVOP | val); 
-  command(PCD8544_FUNCTIONSET);
-  
- }
-
+  writecommand(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
+  writecommand(PCD8544_SETVOP | val);
+  writecommand(PCD8544_FUNCTIONSET);
+}
 
 
 void Adafruit_PCD8544::display(void) {
   uint8_t col, maxcol, p;
-  
+
   for(p = 0; p < 6; p++) {
 #ifdef enablePartialUpdate
     // check if this page is part of update
@@ -245,8 +330,7 @@ void Adafruit_PCD8544::display(void) {
     }
 #endif
 
-    command(PCD8544_SETYADDR | p);
-
+    writecommand(PCD8544_SETYADDR | p);
 
 #ifdef enablePartialUpdate
     col = xUpdateMin;
@@ -257,22 +341,33 @@ void Adafruit_PCD8544::display(void) {
     maxcol = LCDWIDTH-1;
 #endif
 
-    command(PCD8544_SETXADDR | col);
+    writecommand(PCD8544_SETXADDR | col);
 
-    digitalWrite(_dc, HIGH);
-    if (_cs > 0)
-      digitalWrite(_cs, LOW);
+    // digitalWrite(_dc, HIGH);
+    // if (_cs > 0) digitalWrite(_cs, LOW);
+#ifdef __AVR__
+	  *rsport |=  rspinmask;
+	  *csport &= ~cspinmask;
+#endif //#ifdef __AVR__
+#if defined(__SAM3X8E__)
+	  rsport->PIO_SODR |= rspinmask;
+	  csport->PIO_CODR |= cspinmask;
+#endif //#if defined(__SAM3X8E__)
+
     for(; col <= maxcol; col++) {
-      //uart_putw_dec(col);
-      //uart_putchar(' ');
-      fastSPIwrite(pcd8544_buffer[(LCDWIDTH*p)+col]);
+      spiwrite(pcd8544_buffer[(LCDWIDTH*p)+col]);
     }
-    if (_cs > 0)
-      digitalWrite(_cs, HIGH);
 
+    // if (_cs > 0) digitalWrite(_cs, HIGH);
+#ifdef __AVR__
+	  *csport |= cspinmask;
+#endif //#ifdef __AVR__
+#if defined(__SAM3X8E__)
+	  csport->PIO_SODR |= cspinmask;
+#endif //#if defined(__SAM3X8E__)
   }
 
-  command(PCD8544_SETYADDR );  // no idea why this is necessary but it is to finish the last byte?
+  writecommand(PCD8544_SETYADDR );  // no idea why this is necessary but it is to finish the last byte?
 #ifdef enablePartialUpdate
   xUpdateMin = LCDWIDTH - 1;
   xUpdateMax = 0;
@@ -290,13 +385,11 @@ void Adafruit_PCD8544::clearDisplay(void) {
 }
 
 /*
-// this doesnt touch the buffer, just clears the display RAM - might be handy
+// this doesn't touch the buffer, just clears the display RAM - might be handy
 void Adafruit_PCD8544::clearDisplay(void) {
-  
   uint8_t p, c;
-  
-  for(p = 0; p < 8; p++) {
 
+  for(p = 0; p < 8; p++) {
     st7565_command(CMD_SET_PAGE | p);
     for(c = 0; c < 129; c++) {
       //uart_putw_dec(c);
@@ -304,9 +397,7 @@ void Adafruit_PCD8544::clearDisplay(void) {
       st7565_command(CMD_SET_COLUMN_LOWER | (c & 0xf));
       st7565_command(CMD_SET_COLUMN_UPPER | ((c >> 4) & 0xf));
       st7565_data(0x0);
-    }     
     }
-
+  }
 }
-
 */

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -16,12 +16,29 @@ BSD license, check license.txt for more information
 All text above, and the splash screen must be included in any redistribution
 *********************************************************************/
 
-#if defined(ARDUINO) && ARDUINO >= 100
+#ifndef _ADAFRUIT_PCD8544H_
+#define _ADAFRUIT_PCD8544H_
+
+#if ARDUINO >= 100
   #include "Arduino.h"
+  #include "Print.h"
 #else
   #include "WProgram.h"
-  #include "pins_arduino.h"
 #endif
+
+#include <Adafruit_GFX.h>
+
+#if defined(__SAM3X8E__)
+#include <include/pio.h>
+  #define PROGMEM
+  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+  #define pgm_read_word(addr) (*(const unsigned short *)(addr))
+  typedef unsigned char prog_uchar;
+#endif
+#ifdef __AVR__
+  #include <avr/pgmspace.h>
+#endif
+
 
 #define BLACK 1
 #define WHITE 0
@@ -50,10 +67,10 @@ All text above, and the splash screen must be included in any redistribution
 #define PCD8544_SETVOP 0x80
 
 class Adafruit_PCD8544 : public Adafruit_GFX {
- public:
-  Adafruit_PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t CS, int8_t RST);
-  Adafruit_PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t RST);
-
+public:
+  Adafruit_PCD8544(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK, uint8_t RST);
+  Adafruit_PCD8544(uint8_t CS, uint8_t RS, uint8_t RST);
+  
   void begin(uint8_t contrast = 40);
   
   void command(uint8_t c);
@@ -66,11 +83,25 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   uint8_t getPixel(int8_t x, int8_t y);
 
- private:
-  int8_t _din, _sclk, _dc, _rst, _cs;
-  volatile uint8_t *mosiport, *clkport, *csport, *dcport;
-  uint8_t mosipinmask, clkpinmask, cspinmask, dcpinmask;
+protected:
+  void     spiwrite(uint8_t),
+           writecommand(uint8_t c),
+           writedata(uint8_t d);
 
-  void slowSPIwrite(uint8_t c);
-  void fastSPIwrite(uint8_t c);
+  boolean  hwSPI;
+
+#ifdef __AVR__
+  volatile uint8_t *dataport, *clkport, *csport, *rsport;
+  uint8_t  _cs, _rs, _rst, _sid, _sclk,
+           datapinmask, clkpinmask, cspinmask, rspinmask;
+#endif //  #ifdef __AVR__
+
+#if defined(__SAM3X8E__)
+  Pio *dataport, *clkport, *csport, *rsport;
+  uint32_t  _cs, _rs, _rst, _sid, _sclk,
+            datapinmask, clkpinmask, cspinmask, rspinmask;
+#endif //  #if defined(__SAM3X8E__)
+
 };
+
+#endif

--- a/PINS.txt
+++ b/PINS.txt
@@ -1,0 +1,41 @@
+Copyright (c) 2013 Andreas Götz <cpuidle@gmx.de>
+BSD license, check license.txt for more information
+All text above must be included in any redistribution
+
+
+With this update, the pin naming and order has changed to match the Adafruit ST7735 library.
+The old/new pin naming and constructor order ist provided below for reference as well as the
+internal usage
+
+
+PIN naming
+
+  OLD           NEW             SPI library*  Internal usage
+
+  int8_t CS     uint8_t CS      --            Chip select (csport/cspinmask)
+  int8_t DC     uint8_t RS      --            Data/command (dc/rs port/pinmask)
+  int8_t DIN    uint8_t SID     MOSI (11)     Device data in, Master out (mosiport/dataport)
+  int8_t SCLK   uint8_t SCLK    SCK (13)      Clock (clkport/clkpinmask)
+  int8_t RST    uint8_t RST     --            Reset (rsport/rspinmask)
+  --            --              MISO (12)     Master in slave out (not used for display)
+  --            --              SS (10)       Slave select**
+  
+  *Note: SPI library pin numbers are given for Arduino Nano
+
+  **Note about Slave Select (SS) pin on AVR based boards:
+  All AVR based boards have an SS pin that is useful when they act as a slave controlled by an external master. Since this library supports only master mode, this pin should be set always as OUTPUT otherwise the SPI interface could be put automatically into slave mode by hardware, rendering the library inoperative. (http://arduino.cc/de/Reference/SPI)
+
+
+Constructor usage
+
+  OLD
+        // bitbang SPI
+        Adafruit_PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t CS, int8_t RST);
+        // bitbang SPI, caller responsible for chip select
+        Adafruit_PCD8544(int8_t SCLK, int8_t DIN, int8_t DC, int8_t RST);
+
+  NEW
+        // bitbang SPI
+        Adafruit_PCD8544(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK, uint8_t RST);
+        // hardware SPI
+        Adafruit_PCD8544(uint8_t CS, uint8_t RS, uint8_t RST);

--- a/examples/pcdtest/pcdtest.pde
+++ b/examples/pcdtest/pcdtest.pde
@@ -18,13 +18,14 @@ All text above, and the splash screen must be included in any redistribution
 
 #include <Adafruit_GFX.h>
 #include <Adafruit_PCD8544.h>
+#include <SPI.h>
 
-// pin 7 - Serial clock out (SCLK)
-// pin 6 - Serial data out (DIN)
-// pin 5 - Data/Command select (D/C)
-// pin 4 - LCD chip select (CS)
-// pin 3 - LCD reset (RST)
-Adafruit_PCD8544 display = Adafruit_PCD8544(7, 6, 5, 4, 3);
+// new sytax for hardware SPI
+// Nano:  13  SCLK
+//        11  DIN/MOSI
+//        10  CS/SS
+// Adafruit_PCD8544(uint8_t CS, uint8_t RS, uint8_t RST);
+Adafruit_PCD8544 display = Adafruit_PCD8544(10, 5, 3);
 
 #define NUMFLAKES 10
 #define XPOS 0
@@ -192,12 +193,12 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit
       if (icons[f][YPOS] > display.height()) {
-	icons[f][XPOS] = random() % display.width();
-	icons[f][YPOS] = 0;
-	icons[f][DELTAY] = random() % 5 + 1;
+		icons[f][XPOS] = random() % display.width();
+		icons[f][YPOS] = 0;
+		icons[f][DELTAY] = random() % 5 + 1;
       }
     }
-   }
+  }
 }
 
 


### PR DESCRIPTION
This PR is a rewrite of the library based on the recent ST7735 codebase as of commit adafruit/Adafruit-ST7735-Library@98c5d9d1a1899ba6a6cd3d8f5745ae87a1bca29f.

Features:
- hardware SPI 
- add support for Cortex-M3 Arduinos (similar to the ST7735 library)
- PCD8544 displays can be used as drop-in replacements for ST7735-based displays

Included sample code has been tested on Arduino Nano.

Not yet implemented is the ST7735's command-list architecture which could also be ported.

If there is general interest in this patch I propose to push another one that extracts all SPI-specific code into an Adafruit_GFX_SPI class that can be the common basis for all/most Adafruit TFT libraries to simplify maintenance.
