### PR TITLE
Include the parent class

### DIFF
--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -26,6 +26,7 @@ All text above, and the splash screen must be included in any redistribution
 #endif
 
 #include <SPI.h>
+#include <Adafruit_GFX.h>
 
 #define BLACK 1
 #define WHITE 0


### PR DESCRIPTION
This is such an obvious change that I almost just assumed there was a reason it wasn't included... but then I figured it wouldn't hurt to find out, and if this IS a worthwhile change, then no harm in including it!

I discovered this when I `#include <Adafruit_PCD8544.h>` without including the GFX.h as well, and the cpp error message was kind of gibberish-y.
