### PR TITLE
 Add support for Arduino Zero

### DIFF
--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -27,7 +27,7 @@ All text above, and the splash screen must be included in any redistribution
 
 #include <SPI.h>
 
-#ifdef __SAM3X8E__
+#if defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
   typedef volatile RwReg PortReg;
   typedef uint32_t PortMask;
 #else


### PR DESCRIPTION
Add support for Arduino Zero. Tested on Due and Zero. The change does not affect AVR platforms.
