### PR TITLE
works with SAMD21G18 (arduino zero, etc)

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -183,11 +183,13 @@ void Adafruit_PCD8544::begin(uint8_t contrast, uint8_t bias) {
     pinMode(_din, OUTPUT);
     pinMode(_sclk, OUTPUT);
 
+#ifndef __SAMD21G18A__
     // Set software SPI ports and masks.
     clkport     = portOutputRegister(digitalPinToPort(_sclk));
     clkpinmask  = digitalPinToBitMask(_sclk);
     mosiport    = portOutputRegister(digitalPinToPort(_din));
     mosipinmask = digitalPinToBitMask(_din);
+#endif
   }
 
   // Set common pin outputs.
@@ -242,6 +244,10 @@ inline void Adafruit_PCD8544::spiWrite(uint8_t d) {
     SPI.transfer(d);
   }
   else {
+#ifdef __SAMD21G18A__
+    // Software SPI write with shiftOut().
+    shiftOut(_din, _sclk, MSBFIRST, d);
+#else
     // Software SPI write with bit banging.
     for(uint8_t bit = 0x80; bit; bit >>= 1) {
       *clkport &= ~clkpinmask;
@@ -249,6 +255,7 @@ inline void Adafruit_PCD8544::spiWrite(uint8_t d) {
       else        *mosiport &= ~mosipinmask;
       *clkport |=  clkpinmask;
     }
+#endif
   }
 }
 

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -90,8 +90,10 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
 
  private:
   int8_t _din, _sclk, _dc, _rst, _cs;
+#ifndef __SAMD21G18A__
   volatile PortReg  *mosiport, *clkport;
   PortMask mosipinmask, clkpinmask;
+#endif
 
   void spiWrite(uint8_t c);
   bool isHardwareSPI();


### PR DESCRIPTION
Here's a small change to get this library working on a SAMD21G18. I tested it with a SparkFun SAMD21 Mini Breakout since that's what I had (I am interested in the Feather M0 adalogger). It works with the first constructor (all the pins) and the last constructor (hardware SPI). (I didn't test it with the second constructor (all pins except CS) but the code path for that is very similar to the first constructor.)

I'm not sure if this is the best approach since I'm fairly new to the arduino/uc programming world. There might be an easy way of doing the bitbanging on the SAMD but the shiftOut() works pretty well, and is more-or-less twice as slow as the hardware SPI.

(
BTW, this is what I used to test the speed:

``` cpp
            uint32_t iterations = 100;
            uint32_t t0 = millis();
            for (int i = 0; i < iterations; i++) {
                lcd.fillRect(0, 0, 84, 48, 1);
                lcd.display();
                lcd.fillRect(0, 0, 84, 48, 0);
                lcd.display();
            }
            uint32_t t1 = millis();
            SerialUSB.print("iterations=");
            SerialUSB.print(iterations);
            SerialUSB.print("  elapsed=");
            SerialUSB.print(t1 - t0);
            SerialUSB.print("ms  average=");
            SerialUSB.print(float(t1 - t0) / float(iterations));
            SerialUSB.println("ms");
```

The hardware SPI gave me an average of 26ms and the shiftOut() gave me an average of 58ms.
)
