### PR TITLE
make pcdtest better testing utility

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -92,7 +92,6 @@ static uint8_t xUpdateMin, xUpdateMax, yUpdateMin, yUpdateMax;
 #endif
 
 
-
 static void updateBoundingBox(uint8_t xmin, uint8_t ymin, uint8_t xmax, uint8_t ymax) {
 #ifdef enablePartialUpdate
   if (xmin < xUpdateMin) xUpdateMin = xmin;
@@ -212,18 +211,8 @@ void Adafruit_PCD8544::begin(uint8_t contrast, uint8_t bias) {
     digitalWrite(_rst, HIGH);
   }
 
-  // get into the EXTENDED mode!
-  command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
-
-  // LCD bias select (4 is optimal?)
-  command(PCD8544_SETBIAS | bias);
-
-  // set VOP
-  if (contrast > 0x7f)
-    contrast = 0x7f;
-
-  command( PCD8544_SETVOP | contrast); // Experimentally determined
-
+  setBias(bias);
+  setContrast(contrast);
 
   // normal mode
   command(PCD8544_FUNCTIONSET);
@@ -286,6 +275,7 @@ void Adafruit_PCD8544::setContrast(uint8_t val) {
   if (val > 0x7f) {
     val = 0x7f;
   }
+  _contrast = val;
   command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
   command( PCD8544_SETVOP | val); 
   command(PCD8544_FUNCTIONSET);
@@ -296,9 +286,20 @@ void Adafruit_PCD8544::setBias(uint8_t val) {
   if (val > 0x07) {
     val = 0x07;
   }
+  _bias = val;
   command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
   command(PCD8544_SETBIAS | val);
   command(PCD8544_FUNCTIONSET);
+}
+
+uint8_t Adafruit_PCD8544::getBias()
+{
+  return _bias;
+}
+
+uint8_t Adafruit_PCD8544::getContrast()
+{
+  return _contrast;
 }
 
 void Adafruit_PCD8544::display(void) {

--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -292,7 +292,14 @@ void Adafruit_PCD8544::setContrast(uint8_t val) {
   
  }
 
-
+void Adafruit_PCD8544::setBias(uint8_t val) {
+  if (val > 0x07) {
+    val = 0x07;
+  }
+  command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
+  command(PCD8544_SETBIAS | val);
+  command(PCD8544_FUNCTIONSET);
+}
 
 void Adafruit_PCD8544::display(void) {
   uint8_t col, maxcol, p;

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -86,6 +86,7 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   void data(uint8_t c);
   
   void setContrast(uint8_t val);
+  void setBias(uint8_t val);
   void clearDisplay(void);
   void display();
   

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -87,6 +87,8 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   
   void setContrast(uint8_t val);
   void setBias(uint8_t val);
+  uint8_t getContrast(void);
+  uint8_t getBias(void);
   void clearDisplay(void);
   void display();
   
@@ -95,6 +97,7 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
 
  private:
   int8_t _din, _sclk, _dc, _rst, _cs;
+  uint8_t _contrast, _bias;
   volatile PortReg  *mosiport, *clkport;
   PortMask mosipinmask, clkpinmask;
 

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -91,6 +91,8 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   uint8_t getBias(void);
   void clearDisplay(void);
   void display();
+  void setReinitInterval(uint8_t val);
+  uint8_t getReinitInterval(void);
   
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   uint8_t getPixel(int8_t x, int8_t y);
@@ -98,9 +100,11 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
  private:
   int8_t _din, _sclk, _dc, _rst, _cs;
   uint8_t _contrast, _bias;
+  uint8_t _reinit_interval, _display_count;
   volatile PortReg  *mosiport, *clkport;
   PortMask mosipinmask, clkpinmask;
 
+  void initDisplay();
   void spiWrite(uint8_t c);
   bool isHardwareSPI();
 };

--- a/examples/pcdtest/pcdtest.ino
+++ b/examples/pcdtest/pcdtest.ino
@@ -90,7 +90,24 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
     }
     display.display();
     delay(200);
-    
+
+    while(Serial.available()) {
+        switch (Serial.read()) {
+          case 'w':display.setContrast(display.getContrast() + 1);
+                   break;
+          case 's':if(display.getContrast()) display.setContrast(display.getContrast() - 1);
+                     break;
+          case 'e':display.setBias(display.getBias() + 1);
+                   break;
+          case 'd':if(display.getBias()) display.setBias(display.getBias() - 1);
+        }
+    }
+    Serial.print("contrast (w/s): 0x");
+    Serial.print(display.getContrast(), HEX);
+    Serial.print("   bias (e/d): 0x");
+    Serial.print(display.getBias(), HEX);
+    Serial.print("   \r");
+
     // then erase it + move it
     for (uint8_t f=0; f< NUMFLAKES; f++) {
       display.drawBitmap(icons[f][XPOS], icons[f][YPOS],  logo16_glcd_bmp, w, h, WHITE);

--- a/examples/pcdtest/pcdtest.ino
+++ b/examples/pcdtest/pcdtest.ino
@@ -65,127 +65,6 @@ static const unsigned char PROGMEM logo16_glcd_bmp[] =
   B01110000, B01110000,
   B00000000, B00110000 };
 
-void setup()   {
-  Serial.begin(9600);
-
-  display.begin();
-  // init done
-
-  // you can change the contrast around to adapt the display
-  // for the best viewing!
-  display.setContrast(50);
-
-  display.display(); // show splashscreen
-  delay(2000);
-  display.clearDisplay();   // clears the screen and buffer
-
-  // draw a single pixel
-  display.drawPixel(10, 10, BLACK);
-  display.display();
-  delay(2000);
-  display.clearDisplay();
-
-  // draw many lines
-  testdrawline();
-  display.display();
-  delay(2000);
-  display.clearDisplay();
-
-  // draw rectangles
-  testdrawrect();
-  display.display();
-  delay(2000);
-  display.clearDisplay();
-
-  // draw multiple rectangles
-  testfillrect();
-  display.display();
-  delay(2000);
-  display.clearDisplay();
-
-  // draw mulitple circles
-  testdrawcircle();
-  display.display();
-  delay(2000);
-  display.clearDisplay();
-
-  // draw a circle, 10 pixel radius
-  display.fillCircle(display.width()/2, display.height()/2, 10, BLACK);
-  display.display();
-  delay(2000);
-  display.clearDisplay();
-
-  testdrawroundrect();
-  delay(2000);
-  display.clearDisplay();
-
-  testfillroundrect();
-  delay(2000);
-  display.clearDisplay();
-
-  testdrawtriangle();
-  delay(2000);
-  display.clearDisplay();
-   
-  testfilltriangle();
-  delay(2000);
-  display.clearDisplay();
-
-  // draw the first ~12 characters in the font
-  testdrawchar();
-  display.display();
-  delay(2000);
-  display.clearDisplay();
-
-  // text display tests
-  display.setTextSize(1);
-  display.setTextColor(BLACK);
-  display.setCursor(0,0);
-  display.println("Hello, world!");
-  display.setTextColor(WHITE, BLACK); // 'inverted' text
-  display.println(3.141592);
-  display.setTextSize(2);
-  display.setTextColor(BLACK);
-  display.print("0x"); display.println(0xDEADBEEF, HEX);
-  display.display();
-  delay(2000);
-
-  // rotation example
-  display.clearDisplay();
-  display.setRotation(1);  // rotate 90 degrees counter clockwise, can also use values of 2 and 3 to go further.
-  display.setTextSize(1);
-  display.setTextColor(BLACK);
-  display.setCursor(0,0);
-  display.println("Rotation");
-  display.setTextSize(2);
-  display.println("Example!");
-  display.display();
-  delay(2000);
-
-  // revert back to no rotation
-  display.setRotation(0);
-
-  // miniature bitmap display
-  display.clearDisplay();
-  display.drawBitmap(30, 16,  logo16_glcd_bmp, 16, 16, 1);
-  display.display();
-
-  // invert the display
-  display.invertDisplay(true);
-  delay(1000); 
-  display.invertDisplay(false);
-  delay(1000); 
-
-  // draw a bitmap icon and 'animate' movement
-  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_WIDTH, LOGO16_GLCD_HEIGHT);
-}
-
-
-void loop() {
-  
-}
-
-
 void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
   uint8_t icons[NUMFLAKES][3];
   randomSeed(666);     // whatever seed
@@ -347,4 +226,124 @@ void testdrawline() {
     display.display();
   }
   delay(250);
+}
+
+void setup()   {
+  Serial.begin(9600);
+
+  display.begin();
+  // init done
+
+  // you can change the contrast around to adapt the display
+  // for the best viewing!
+  display.setContrast(50);
+
+  display.display(); // show splashscreen
+  delay(2000);
+  display.clearDisplay();   // clears the screen and buffer
+
+  // draw a single pixel
+  display.drawPixel(10, 10, BLACK);
+  display.display();
+  delay(2000);
+  display.clearDisplay();
+
+  // draw many lines
+  testdrawline();
+  display.display();
+  delay(2000);
+  display.clearDisplay();
+
+  // draw rectangles
+  testdrawrect();
+  display.display();
+  delay(2000);
+  display.clearDisplay();
+
+  // draw multiple rectangles
+  testfillrect();
+  display.display();
+  delay(2000);
+  display.clearDisplay();
+
+  // draw mulitple circles
+  testdrawcircle();
+  display.display();
+  delay(2000);
+  display.clearDisplay();
+
+  // draw a circle, 10 pixel radius
+  display.fillCircle(display.width()/2, display.height()/2, 10, BLACK);
+  display.display();
+  delay(2000);
+  display.clearDisplay();
+
+  testdrawroundrect();
+  delay(2000);
+  display.clearDisplay();
+
+  testfillroundrect();
+  delay(2000);
+  display.clearDisplay();
+
+  testdrawtriangle();
+  delay(2000);
+  display.clearDisplay();
+   
+  testfilltriangle();
+  delay(2000);
+  display.clearDisplay();
+
+  // draw the first ~12 characters in the font
+  testdrawchar();
+  display.display();
+  delay(2000);
+  display.clearDisplay();
+
+  // text display tests
+  display.setTextSize(1);
+  display.setTextColor(BLACK);
+  display.setCursor(0,0);
+  display.println("Hello, world!");
+  display.setTextColor(WHITE, BLACK); // 'inverted' text
+  display.println(3.141592);
+  display.setTextSize(2);
+  display.setTextColor(BLACK);
+  display.print("0x"); display.println(0xDEADBEEF, HEX);
+  display.display();
+  delay(2000);
+
+  // rotation example
+  display.clearDisplay();
+  display.setRotation(1);  // rotate 90 degrees counter clockwise, can also use values of 2 and 3 to go further.
+  display.setTextSize(1);
+  display.setTextColor(BLACK);
+  display.setCursor(0,0);
+  display.println("Rotation");
+  display.setTextSize(2);
+  display.println("Example!");
+  display.display();
+  delay(2000);
+
+  // revert back to no rotation
+  display.setRotation(0);
+
+  // miniature bitmap display
+  display.clearDisplay();
+  display.drawBitmap(30, 16,  logo16_glcd_bmp, 16, 16, 1);
+  display.display();
+
+  // invert the display
+  display.invertDisplay(true);
+  delay(1000); 
+  display.invertDisplay(false);
+  delay(1000); 
+
+  // draw a bitmap icon and 'animate' movement
+  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_WIDTH, LOGO16_GLCD_HEIGHT);
+}
+
+
+void loop() {
+  
 }

--- a/examples/pcdtest/pcdtest.ino
+++ b/examples/pcdtest/pcdtest.ino
@@ -254,6 +254,7 @@ void setup()   {
   // you can change the contrast around to adapt the display
   // for the best viewing!
   display.setContrast(50);
+  display.setReinitInterval(10);
 
   display.display(); // show splashscreen
   delay(2000);


### PR DESCRIPTION
it turns out that setting correct contrast is vital for getting usable picture with a 5110 LCD. I have a couple of them and each requires a different setting.

Setting bias is less important - you just have to set contrast to match. Lower bias needs higher contrast.

To test this I updated the pcdtest with serial user input for setting contrast and bias in the final falling flowers demo.

Last piece is a bit problematic - it makes the demo somewhat robust to loose contact (eg on the rubber under the display) but it makes the picture go away repeatedly because the reset takes way tool long.
