### PR TITLE
Fixes compile errors on ESP8266

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -16,8 +16,6 @@ BSD license, check license.txt for more information
 All text above, and the splash screen below must be included in any redistribution
 *********************************************************************/
 
-//#include <Wire.h>
-#include <avr/pgmspace.h>
 #if defined(ARDUINO) && ARDUINO >= 100
   #include "Arduino.h"
 #else

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -27,7 +27,10 @@ All text above, and the splash screen must be included in any redistribution
 
 #include <SPI.h>
 
-#if  defined(__SAM3X8E__) || defined(ARDUINO_ARCH_SAMD)
+#ifdef ESP8266
+  typedef volatile uint32_t PortReg;
+  typedef uint32_t PortMask;
+#elif defined(__SAM3X8E__) || defined(ARDUINO_ARCH_SAMD)
   typedef volatile RwReg PortReg;
   typedef uint32_t PortMask;
 #else


### PR DESCRIPTION
Removes obsolete headers and adds PortReg definition. Tested to make sure it still compiles on AVR boards.