### PR TITLE
Fix build issues on esp32 and pic32 platforms.

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -17,7 +17,10 @@ All text above, and the splash screen below must be included in any redistributi
 *********************************************************************/
 
 //#include <Wire.h>
+#ifdef __AVR__
 #include <avr/pgmspace.h>
+#endif
+
 #if defined(ARDUINO) && ARDUINO >= 100
   #include "Arduino.h"
 #else

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -30,9 +30,12 @@ All text above, and the splash screen must be included in any redistribution
 #if  defined(__SAM3X8E__) || defined(ARDUINO_ARCH_SAMD)
   typedef volatile RwReg PortReg;
   typedef uint32_t PortMask;
-#else
+#elif defined(__AVR__)
   typedef volatile uint8_t PortReg;
   typedef uint8_t PortMask;
+#else
+  typedef volatile uint32_t PortReg;
+  typedef uint32_t PortMask;
 #endif
 
 


### PR DESCRIPTION
This change modifies files Adafruit_PCD8544.h and Adafruit_PCD8544.cpp, to allow compilation on ESP32 and PIC32 platforms. 

File Adafruit_PCD8544.h: include file <avr/pgmspace.h> only on AVR platform.

File Adafruit_PCD8544.cpp: define types PortReg; and PortMask as 32-bit values for platforms other than AVR.