### PR TITLE
Fix -Wunused-parameter warnings

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -131,6 +131,12 @@ static void updateBoundingBox(uint8_t xmin, uint8_t ymin, uint8_t xmax,
     yUpdateMin = ymin;
   if (ymax > yUpdateMax)
     yUpdateMax = ymax;
+#else
+  // Disable -Wunused-parameter warnings.
+  (void)xmin;
+  (void)ymin;
+  (void)xmax;
+  (void)ymax;
 #endif
 }
 


### PR DESCRIPTION
Fixes the following compiler warnings from Arduino IDE or Arduino CLI with warnings enabled. No function change:

```
/home/brian/src/arduino/libraries/Adafruit-PCD8544-Nokia-5110-LCD-library/Adafruit_PCD8544.cpp:123:13: warning: unused parameter 'xmin' [-Wunused-parameter]
 static void updateBoundingBox(uint8_t xmin, uint8_t ymin, uint8_t xmax,
             ^
/home/brian/src/arduino/libraries/Adafruit-PCD8544-Nokia-5110-LCD-library/Adafruit_PCD8544.cpp:123:13: warning: unused parameter 'ymin' [-Wunused-parameter]
/home/brian/src/arduino/libraries/Adafruit-PCD8544-Nokia-5110-LCD-library/Adafruit_PCD8544.cpp:123:13: warning: unused parameter 'xmax' [-Wunused-parameter]
/home/brian/src/arduino/libraries/Adafruit-PCD8544-Nokia-5110-LCD-library/Adafruit_PCD8544.cpp:123:13: warning: unused parameter 'ymax' [-Wunused-parameter]
```