### PR TITLE
[Memory management] Add virtual destructor for improved memory management

### DIFF
--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -68,6 +68,8 @@ public:
   Adafruit_PCD8544(int8_t dc_pin, int8_t cs_pin, int8_t rst_pin,
                    SPIClass *theSPI = &SPI);
 
+  virtual ~Adafruit_PCD8544() {}
+
   bool begin(uint8_t contrast = 40, uint8_t bias = 0x04);
 
   void command(uint8_t c);


### PR DESCRIPTION
Feature:
Adds a `virtual` destructor to stop the compiler moaning about the destructor not being virtual when `delete`ing the instance.

To improve memory management, by allowing the instance created to be deleted, for use in a plugin-based system ([ESPEasy](https://github.com/letscontrolit/ESPEasy/))

